### PR TITLE
chore: use hashicorp/consul in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
         environment:
           CIRCLE_TEST_REPORTS: /tmp/circle-reports
           CIRCLE_ARTIFACTS: /tmp/circle-artifacts
-      - image: consul
+      - image: hashicorp/consul
 
     steps:
       - checkout


### PR DESCRIPTION
This PR intends to fix our broken CI workflow. 

Looks like the old `consul` image was deprecated. README indicates to use the new [hashicorp/consul image](https://hub.docker.com/r/hashicorp/consul).