### PR TITLE
chore: Use gh-actions/actions/persistent-stores

### DIFF
--- a/.github/workflows/common_ci.yml
+++ b/.github/workflows/common_ci.yml
@@ -11,13 +11,11 @@ jobs:
   unit-test-and-coverage:
     runs-on: ubuntu-latest
     name: 'Unit Tests and Coverage'
-    services:
-      consul:
-        image: hashicorp/consul
-        ports:
-          - 8500:8500
     steps:
       - uses: actions/checkout@v4
+      - uses: launchdarkly/gh-actions/actions/persistent-stores@persistent-stores-v0
+        with:
+          consul: true
       - name: Setup Go ${{ inputs.go-version }}
         uses: actions/setup-go@v5
         with:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-
+# Repository Maintainers
+* @launchdarkly/team-sdk-go


### PR DESCRIPTION
The latest consul image incorrectly handles a '$' in the key name. This
is causing failing tests since we use an '$inited' key. Until the consul
change is remedied, we need to pin to a working version of consul.

This is already done in our shared GH action for persistent stores, so I
am updating this SDK to finally use that.
