### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -16,7 +16,7 @@ jobs:
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
-        uses: JamesIves/fetch-api-data-action@396ebea7d13904824f85b892b1616985f847301c
+        uses: JamesIves/fetch-api-data-action@396ebea7d13904824f85b892b1616985f847301c # 396ebea7d13904824f85b892b1616985f847301c
         with:
           endpoint: https://endoflife.date/api/go.json
           configuration: '{ "method": "GET" }'
@@ -61,7 +61,7 @@ jobs:
 
       - name: Create pull request
         if: steps.update-go-versions.outcome == 'success'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           target-branch: v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           target-branch: v3


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that pin existing third-party actions to specific commit SHAs; behavior should remain the same aside from using fixed revisions.
> 
> **Overview**
> Pins third-party GitHub Actions to full commit SHAs in CI workflows to reduce supply-chain risk.
> 
> `check-go-versions.yml` now uses pinned revisions for `JamesIves/fetch-api-data-action` and `peter-evans/create-pull-request`, and `release-please.yml` pins `googleapis/release-please-action` to a specific commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit baf79da4856f947f8e441b3e3bbcab0fd9bca831. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->