### PR TITLE
fix: Bump minimum go version to 1.25

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,3 +1,3 @@
 latest=1.26
 penultimate=1.25
-min=1.24
+min=1.25

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk-consul/v3
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/hashicorp/consul/api v1.12.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Toolchain and CI version bumps only; no application or dependency logic changes.
> 
> **Overview**
> **Raises the minimum supported Go version from 1.24 to 1.25** in both the module declaration and CI configuration.
> 
> `go.mod` now declares `go 1.25.0`, and `.github/variables/go-versions.env` updates `min` from `1.24` to `1.25` so workflows that read that file test against the same floor as the module requires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7464572caf00363c43ad34bd9f5fb9502ddad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->