### PR TITLE
fix: Bump minimum Go version to 1.26

### DIFF
--- a/.github/variables/go-versions.env
+++ b/.github/variables/go-versions.env
@@ -1,3 +1,3 @@
 latest=1.27
 penultimate=1.26
-min=1.25
+min=1.26

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This library provides a [Consul](https://www.consul.io/)-backed persistence mech
 
 This version of the library requires at least version 6.0.0 of the LaunchDarkly Go SDK; for versions of the library to use with earlier SDK versions, see the changelog.
 
-The minimum Go version is 1.18.
+The minimum Go version is 1.26.
 
 For more information, see also: [Using Consul as a persistent feature store](https://docs.launchdarkly.com/sdk/features/storing-data/consul#go).
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/go-server-sdk-consul/v3
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/hashicorp/consul/api v1.12.0


### PR DESCRIPTION
Go 1.25 is no longer an officially supported release, so the module now
requires Go 1.26. The CI matrix already tested 1.27 and 1.26; setting
min=1.26 collapses the matrix to those two versions.

Also correct the minimum version stated in the README, which still said
1.18.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Raises the module’s **minimum Go version to 1.26** by updating `go.mod` (`go 1.26.0`) and aligning CI config in `.github/variables/go-versions.env` (`min=1.26`), so builds no longer target the unsupported 1.25 line.
> 
> Updates the **README** to state the correct minimum (**1.26** instead of the outdated **1.18**), matching the module requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit babc38b847b64fe59f3825cc6bd024380fddeab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->